### PR TITLE
1015 feedback

### DIFF
--- a/user_server/src/lib/common/middleware/logger.middleware.ts
+++ b/user_server/src/lib/common/middleware/logger.middleware.ts
@@ -11,6 +11,8 @@ export class LoggerMiddleware implements NestMiddleware {
         private readonly jwtService: JwtService,
         // private readonly userService: UserService
     ){}
+
+    // 인터셉터나 가드를 통해서 복호화하는 거 1. 롤에 대해 분별하는거 2
         //service를 통해서 repo를 할지. 아니면 바로 repo로 접근할지 ?
     async use(req: Request, res: Response, next: NextFunction){
         console.log('middleware request!!!')

--- a/user_server/src/schema.gql
+++ b/user_server/src/schema.gql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type UserToken {
+  userIdx: Int!
+  token: String!
+}
+
 type User {
   userIdx: Int!
   id: String!
@@ -11,6 +16,7 @@ type User {
   created: DateTime!
   status: String
   role: String!
+  userToken: UserToken!
 }
 
 """
@@ -18,14 +24,10 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
-type UserToken {
-  userIdx: Int!
-  token: String!
-}
-
 type Query {
   getUserList(input: GetUserListDTO!): [User!]!
   getUserData(userIdx: Int!): User!
+  test(userIdx: Int!): User!
 }
 
 input GetUserListDTO {

--- a/user_server/src/user/entities/user.entity.ts
+++ b/user_server/src/user/entities/user.entity.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { UserToken } from 'src/user-token/entities/user-token.entity';
 import { BaseEntity, Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @ObjectType()
@@ -37,6 +38,6 @@ export class User {
   @Column()
   role: string
 
-  // @Field(type => UserToken)
-  // userToken: UserToken;
+  @Field(type => UserToken)
+  userToken: UserToken;
 }

--- a/user_server/src/user/user.resolver.ts
+++ b/user_server/src/user/user.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, Int, ResolveField, Parent } from '@nestjs/graphql';
 import { UserService } from './user.service';
 import { User } from './entities/user.entity';
 import { SignUpInputDTO } from './dto/input/signUp-input.dto';
@@ -43,7 +43,8 @@ export class UserResolver {
   //기존 signIn과 달라진 점 : force여부를 flag로 두어서 중복되는 코드를 없앰
   @Mutation(()=> User)
   async signIn(@Args('input') loginInputDTO: LoginInputDTO){
-    return await this.userService.signIn(loginInputDTO.id, loginInputDTO.pw, loginInputDTO.isForce);
+    // 주소 참조를 안하기 위해서 새로 오브젝트로 만들어서 새로운 주소로 만들기 위함
+    return await this.userService.signIn({ id:loginInputDTO.id, pw: loginInputDTO.pw, isForce: loginInputDTO.isForce });
   }
 
   //need middleware
@@ -69,6 +70,23 @@ export class UserResolver {
   async getUserData(@Args('userIdx', { type: () => Int }) userIdx: number){
     
   }
+  @Query(()=> User, {name: 'test'})
+  async find(@Args('userIdx', { type: () => Int }) userIdx: number){
+    return await this.userService.testFind(userIdx);
+  }
 
+  @ResolveField()
+  async userIdx(@Parent() user: User) {
+    return '211231321'
+  }
+
+  @ResolveField()
+  async userToken(@Parent() user: User) {
+    const { userIdx } = user;
+    return {
+      userIdx: 1,
+      token: 'adsfsdf'
+    }
+  }
 
 }

--- a/user_server/src/user/user.service.ts
+++ b/user_server/src/user/user.service.ts
@@ -10,10 +10,19 @@ import { JwtService } from '../lib/common/jwt';
 
 @Injectable()
 export class UserService {
+  
   constructor(
     private userRepo: UserRepo, private readonly mailService: MailService,
     private readonly jwtService: JwtService,
   ){}
+
+  async testFind(userIdx: number) {
+    return await this.userRepo.findOne({
+      where : {
+       userIdx : userIdx 
+      }
+    });
+  }
 
   async getUserList(page: number, nickName: string) {
     console.log(page)
@@ -85,7 +94,7 @@ export class UserService {
     return userToken;
   }
 
-  async signIn(id: string, pw: string, isForce: boolean) {
+  async signIn({ id, pw, isForce }: { id: string, pw: string, isForce: boolean }) {
     let user:User = new User();
     try{
       user = await this.userRepo.findUserById(id);


### PR DESCRIPTION
- module에서 미들웨어를 걸어버리게 되면 query | mutation에 걸리기때문에 resolver 파일 안에서 guard와 interceptor를 사용하여 2중 잠금(복호화 -> role 검증)
- object나 array의 값은 주소참조를 통해 이루어진다. 그래서 값 참조를 위해 다시 한 번 오브젝트를 새로 만드는 등의 (더 공부해보기 주소참조!)
- GraphQL의 가장 큰 강점인 ResolveField를 통해 User가 가지고 있는 UserToken을 가지고 올 수 있고, 이로 인해 1+N 문제가 발생할 수 있다(담주에 더 공부해보기)
- Try catch문도 레이어에 따라서 감싸주기 !
- promise문법과 같은 비동기 통신일 때는 return await와 같이 바로 전달하는 것은 큰 오류가 날 수 있음. 특히나 DB에서 값을 가져올 때 ! 그러니깐 절대 주의할 것
- 이력서 : 느낀점과 같은 부분 추가